### PR TITLE
Update `connect` to pass `--script` option

### DIFF
--- a/openconnect_helper.py
+++ b/openconnect_helper.py
@@ -177,6 +177,7 @@ class ProfileManager(object):
         fingerprint = profile.get('fingerprint')
         if fingerprint is not None:
             args.append('--servercert=%s' % fingerprint)
+        args.append('--script=/etc/vpnc/vpnc-script')
         args.append(profile['url'])
 
         c = Popen(args, **kwargs)


### PR DESCRIPTION
It appears the `openconnect` that's installed via `brew` does not run the `vpnc-script` by default. Simply appending `--script` to the call fixes the problem.

Tested on OS X El Capitain.

PS: Additionally, I had to use a custom `vpnc-script` than the one linked at the openconnect site: https://gist.github.com/fcurella/7b6ca3b734864f948bba
